### PR TITLE
Added support for Shapely Point and MultiPoint to Vsketch.geometry() …

### DIFF
--- a/vsketch/vsketch.py
+++ b/vsketch/vsketch.py
@@ -1005,8 +1005,8 @@ class Vsketch:
     def geometry(self, shape: Any) -> None:
         """Draw a Shapely geometry.
 
-        This function should accept any of LineString, LinearRing, MultiPolygon,
-        MultiLineString, or Polygon.
+        This function should accept any of LineString, LinearRing, MultiPoint,
+        MultiPolygon, MultiLineString, Point, or Polygon.
 
         Args:
             shape (Shapely geometry): a supported shapely geometry object
@@ -1027,6 +1027,11 @@ class Vsketch:
                     self.polygon(
                         p.exterior.coords, holes=[hole.coords for hole in p.interiors]
                     )
+            elif shape.geom_type in ["Point", "MultiPoint"]:
+                if shape.geom_type == "Point":
+                    shape = [shape]
+                for p in shape:
+                    self.point(p.x, p.y)
             else:
                 raise ValueError("unsupported Shapely geometry")
         except AttributeError:


### PR DESCRIPTION
…(#157)

#### Description

...

#### Checklist

- [ ] feature/fix implemented
- [ ] `mypy` returns no error
- [ ] tests added/updated and `pytest --runslow` succeeds
- [ ] documentation added/updated and building with no error (`make clean && make html` in `docs/`)
- [ ] examples added/updated
- [ ] code formatting ok (`black` and `isort`)
